### PR TITLE
Fix: Handle multiple word arguments correctly in wlog

### DIFF
--- a/tests/wlog.bats
+++ b/tests/wlog.bats
@@ -74,3 +74,23 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Logged: Test message" ]]
 }
+
+@test "wlog handles messages with spaces correctly" {
+    run ./wlog "message with multiple spaces"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Logged: message with multiple spaces" ]]
+    
+    # Check that the full message is stored in the log file
+    message=$(jq -r '.entries[0].message' "$LOG_FILE")
+    [ "$message" = "message with multiple spaces" ]
+}
+
+@test "wlog handles unquoted multi-word arguments" {
+    run ./wlog testing multiple words
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Logged: testing multiple words" ]]
+    
+    # Check that all words are captured
+    message=$(jq -r '.entries[0].message' "$LOG_FILE")
+    [ "$message" = "testing multiple words" ]
+}

--- a/wlog
+++ b/wlog
@@ -21,7 +21,7 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
-MESSAGE="$1"
+MESSAGE="$*"
 
 # Check if jq is available
 if ! command -v jq >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Fixes issue where `wlog` only captured the first word when multiple unquoted words were provided as arguments
- Changes `MESSAGE="$1"` to `MESSAGE="$*"` to capture all command-line arguments
- Adds comprehensive test coverage for both quoted and unquoted multi-word messages

## Test plan
- [x] Added test case for quoted multi-word messages
- [x] Added test case for unquoted multi-word arguments  
- [x] All existing tests continue to pass
- [x] Manual testing confirms `wlog hello world` now logs "hello world" instead of just "hello"

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)