### PR TITLE
feat: add 'wlog pop' command to remove latest entry

### DIFF
--- a/tests/wlog.bats
+++ b/tests/wlog.bats
@@ -94,3 +94,100 @@ teardown() {
     message=$(jq -r '.entries[0].message' "$LOG_FILE")
     [ "$message" = "testing multiple words" ]
 }
+
+@test "wlog pop shows error when no log file exists" {
+    run ./wlog pop
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "No entries found for today to remove." ]]
+}
+
+@test "wlog pop shows error when log file has no entries" {
+    # Create empty log file
+    cat > "$LOG_FILE" << EOF
+{
+  "date": "$TEST_DATE",
+  "entries": []
+}
+EOF
+    
+    run ./wlog pop
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "No entries found for today to remove." ]]
+}
+
+@test "wlog pop removes the latest entry" {
+    # Create multiple entries
+    run ./wlog "First entry"
+    run ./wlog "Second entry"
+    run ./wlog "Third entry"
+    
+    # Verify we have 3 entries
+    entries_count=$(jq '.entries | length' "$LOG_FILE")
+    [ "$entries_count" -eq 3 ]
+    
+    # Pop the latest entry
+    run ./wlog pop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Removed:" ]]
+    [[ "$output" =~ "Third entry" ]]
+    
+    # Verify we now have 2 entries
+    entries_count=$(jq '.entries | length' "$LOG_FILE")
+    [ "$entries_count" -eq 2 ]
+    
+    # Verify the remaining entries are correct
+    first_message=$(jq -r '.entries[0].message' "$LOG_FILE")
+    second_message=$(jq -r '.entries[1].message' "$LOG_FILE")
+    
+    [ "$first_message" = "First entry" ]
+    [ "$second_message" = "Second entry" ]
+}
+
+@test "wlog pop shows removed entry with timestamp" {
+    # Create an entry
+    run ./wlog "Test entry for removal"
+    
+    # Get the timestamp that was created
+    timestamp=$(jq -r '.entries[0].timestamp' "$LOG_FILE")
+    
+    # Pop the entry
+    run ./wlog pop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Removed: $timestamp - Test entry for removal" ]]
+}
+
+@test "wlog pop can remove all entries one by one" {
+    # Create multiple entries
+    run ./wlog "Entry 1"
+    run ./wlog "Entry 2"
+    run ./wlog "Entry 3"
+    
+    # Pop all entries
+    run ./wlog pop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Entry 3" ]]
+    
+    run ./wlog pop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Entry 2" ]]
+    
+    run ./wlog pop
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Entry 1" ]]
+    
+    # Verify no entries left
+    entries_count=$(jq '.entries | length' "$LOG_FILE")
+    [ "$entries_count" -eq 0 ]
+    
+    # Try to pop again - should fail
+    run ./wlog pop
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "No entries found for today to remove." ]]
+}
+
+@test "wlog pop updates usage message" {
+    run ./wlog
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Usage: wlog \"message\" or wlog pop" ]]
+    [[ "$output" =~ "wlog pop" ]]
+}

--- a/wlog
+++ b/wlog
@@ -14,10 +14,46 @@ LOG_FILE="$WLOG_DIR/$DATE.json"
 # Create directory if it doesn't exist
 mkdir -p "$WLOG_DIR"
 
+# Check if pop command is being used
+if [ $# -eq 1 ] && [ "$1" = "pop" ]; then
+    # Handle pop functionality
+    if [ ! -f "$LOG_FILE" ]; then
+        echo "No entries found for today to remove."
+        exit 1
+    fi
+    
+    # Check if jq is available
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "Error: jq is required but not installed. Please install jq to use wlog."
+        echo "On Ubuntu/Debian: sudo apt install jq"
+        echo "On CentOS/RHEL: sudo yum install jq"
+        echo "On macOS: brew install jq"
+        exit 1
+    fi
+    
+    # Check if there are any entries to remove
+    entry_count=$(jq '.entries | length' "$LOG_FILE")
+    if [ "$entry_count" -eq 0 ]; then
+        echo "No entries found for today to remove."
+        exit 1
+    fi
+    
+    # Get the last entry before removing it
+    last_entry=$(jq -r '.entries[-1] | "\(.timestamp) - \(.message)"' "$LOG_FILE")
+    
+    # Remove the last entry
+    tmp_file=$(mktemp)
+    jq '.entries |= .[:-1]' "$LOG_FILE" > "$tmp_file" && mv "$tmp_file" "$LOG_FILE"
+    
+    echo "Removed: $last_entry"
+    exit 0
+fi
+
 # Check if message is provided
 if [ $# -eq 0 ]; then
-    echo "Usage: wlog \"message\""
+    echo "Usage: wlog \"message\" or wlog pop"
     echo "Example: wlog \"Helped Joe with cluster configuration\""
+    echo "         wlog pop"
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Adds new `wlog pop` command to remove the most recent log entry from today's log
- Provides user-friendly confirmation showing timestamp and message of removed entry
- Handles edge cases gracefully (no log file, empty entries)
- Updates usage text to include the new pop command

## Test plan
- [x] All existing tests continue to pass
- [x] 6 new comprehensive test cases covering pop functionality
- [x] Error handling for missing files and empty logs
- [x] Proper removal of latest entry while preserving others
- [x] Correct display of removed entry details
- [x] Updated help text verification

🤖 Generated with [Claude Code](https://claude.ai/code)